### PR TITLE
Units from profile

### DIFF
--- a/src/main/kotlin/hs/flensburg/marlin/business/api/location/boundary/LocationResources.kt
+++ b/src/main/kotlin/hs/flensburg/marlin/business/api/location/boundary/LocationResources.kt
@@ -56,13 +56,12 @@ fun Application.configureLocation() {
             val locationId = call.parameters["id"]?.toLongOrNull()
                 ?: return@get call.respondText("Missing or wrong id", status = HttpStatusCode.BadRequest)
 
-            val result = TimezonesService.withResolvedTimezone<DetailedLocationDTO>(
+            val tz = TimezonesService.getClientTimeZoneFromIPOrQueryParam(
                 call.parameters["timezone"],
                 call.request.origin.remoteAddress
-            ) { tz ->
-                LocationService.getLocationByID(locationId, tz)
-            }
-            call.respondKIO(result)
+            )
+
+            call.respondKIO(LocationService.getLocationByID(locationId, tz))
         }
 
         get(
@@ -134,13 +133,12 @@ fun Application.configureLocation() {
             ) {
                 val user = call.principal<LoggedInUser>()!!
 
-                val result = TimezonesService.withResolvedTimezone<DetailedLocationDTO>(
+                val tz = TimezonesService.getClientTimeZoneFromIPOrQueryParam(
                     call.parameters["timezone"],
                     call.request.origin.remoteAddress
-                ) { tz ->
-                    LocationService.getHarborMasterAssignedLocation(user.id, tz)
-                }
-                call.respondKIO(result)
+                )
+
+                call.respondKIO(LocationService.getHarborMasterAssignedLocation(user.id, tz))
             }
 
             put(
@@ -194,13 +192,12 @@ fun Application.configureLocation() {
                 val request = call.receive<UpdateLocationRequest>()
 
 
-                val result = TimezonesService.withResolvedTimezone<DetailedLocationDTO>(
+                val tz = TimezonesService.getClientTimeZoneFromIPOrQueryParam(
                     call.parameters["timezone"],
                     call.request.origin.remoteAddress
-                ) { tz ->
-                    LocationService.updateLocationByID(user.id, id, request, tz)
-                }
-                call.respondKIO(result)
+                )
+
+                call.respondKIO(LocationService.updateLocationByID(user.id, id, request, tz))
             }
 
             delete(

--- a/src/main/kotlin/hs/flensburg/marlin/business/api/openAPI/SensorsOpenAPISpec.kt
+++ b/src/main/kotlin/hs/flensburg/marlin/business/api/openAPI/SensorsOpenAPISpec.kt
@@ -1,0 +1,244 @@
+package hs.flensburg.marlin.business.api.openAPI
+
+import hs.flensburg.marlin.business.api.location.entity.DetailedLocationDTO
+import hs.flensburg.marlin.business.api.sensors.entity.LocationWithBoxesDTO
+import hs.flensburg.marlin.business.api.sensors.entity.LocationWithLatestMeasurementsDTO
+import hs.flensburg.marlin.business.api.sensors.entity.UnitsWithLocationWithBoxesDTO
+import hs.flensburg.marlin.business.api.sensors.entity.raw.MeasurementDTO
+import hs.flensburg.marlin.business.api.sensors.entity.raw.MeasurementTypeDTO
+import hs.flensburg.marlin.business.api.sensors.entity.raw.SensorDTO
+import io.github.smiley4.ktoropenapi.config.RouteConfig
+import io.ktor.http.HttpStatusCode
+
+object SensorsOpenAPISpec {
+
+    val getAllSensors: RouteConfig.() -> Unit = {
+        tags("raw")
+        description = "Return all sensors from the database (raw form, no aggregation)."
+        response {
+            HttpStatusCode.OK to {
+                description = "List of sensors"
+                body<List<SensorDTO>>()
+            }
+            HttpStatusCode.InternalServerError to {
+                description = "Error retrieving sensors"
+            }
+        }
+    }
+
+    val getAllMeasurementTypes: RouteConfig.() -> Unit = {
+        tags("raw")
+        description = "Return all measurement types (raw form)."
+        response {
+            HttpStatusCode.OK to {
+                description = "List of measurement types"
+                body<List<MeasurementTypeDTO>>()
+            }
+        }
+    }
+
+    val getAllLocations: RouteConfig.() -> Unit = {
+        tags("location")
+        description = "Return all locations."
+        request {
+            queryParameter<String>("timezone") {
+                description =
+                    "Optional timezone ('Europe/Berlin'). Defaults to Ip address based timezone. Backup UTC."
+                required = false
+            }
+        }
+        response {
+            HttpStatusCode.OK to {
+                description = "List of locations"
+                body<List<DetailedLocationDTO>>()
+            }
+        }
+    }
+
+    val getAllMeasurements: RouteConfig.() -> Unit = {
+        tags("measurements")
+        description = "Return all measurements (raw form)."
+        response {
+            HttpStatusCode.OK to {
+                description = "List of measurements"
+                body<List<MeasurementDTO>>()
+            }
+        }
+    }
+
+    val getLatestMeasurements: RouteConfig.() -> Unit = {
+        tags("measurements")
+        description = "Return the latest measurement for each location (raw form)."
+        response {
+            HttpStatusCode.OK to {
+                description = "List of locations with their latest measurements"
+                body<List<LocationWithLatestMeasurementsDTO>>()
+            }
+        }
+    }
+
+    val getLatestMeasurementsNew: RouteConfig.() -> Unit = {
+        tags("measurements")
+        description =
+            "Get the latest measurement values for all locations. The measurement must be within the last 2 hours."
+        request {
+            queryParameter<String>("timezone") {
+                description =
+                    "Optional timezone ('Europe/Berlin'). Defaults to Ip address based timezone. Backup UTC."
+                required = false
+            }
+            queryParameter<String>("units") {
+                description =
+                    "Optional units for the measurements ('metric, imperial, custom'). Defaults to metric."
+                required = false
+            }
+        }
+        response {
+            HttpStatusCode.OK to {
+                description = "Successful response with latest measurements for each location"
+                body<List<LocationWithBoxesDTO>>()
+            }
+            HttpStatusCode.InternalServerError to {
+                description = "Error occurred while retrieving the latest measurements"
+            }
+        }
+    }
+
+    val getLocationMeasurementsWithinTimeRangeFast: RouteConfig.() -> Unit = {
+        tags("location")
+        description = "Get all measurements for a location within a given time range"
+        request {
+            pathParameter<Long>("id") {
+                description = "The location ID (not the sensor ID)"
+            }
+            queryParameter<String>("timeRange") {
+                description = """Optional time range ('48h', '7d', '30d', '1y'). Defaults to 24h.
+                            |           "24h" -> raw;
+                                        "48h" -> raw;
+                                        "7d"  -> avg: 2 hours;
+                                        "30d" -> avg: 6 hours;
+                                        "90d"  -> avg: 12 hours;
+                                        "180d" -> avg: 1 day;
+                                        "1y"  -> avg: 2 days;
+                        """.trimMargin()
+                required = false
+            }
+            queryParameter<String>("timezone") {
+                description =
+                    "Optional timezone ('Europe/Berlin'). Defaults to Ip address based timezone. Backup UTC."
+                required = false
+            }
+            queryParameter<String>("units") {
+                description =
+                    "Optional units for the measurements ('metric, imperial, custom'). Defaults to metric."
+                required = false
+            }
+        }
+        response {
+            HttpStatusCode.OK to {
+                description = "Successful response with measurements"
+                body<LocationWithBoxesDTO>()
+            }
+            HttpStatusCode.BadRequest to {
+                description = "Invalid parameters"
+            }
+        }
+    }
+
+    val getLatestMeasurementsV3: RouteConfig.() -> Unit = {
+        tags("measurements")
+        description =
+            "Get the latest measurement values for all locations. The measurement must be within the last 2 hours. Version 3."
+        request {
+            queryParameter<String>("timezone") {
+                description =
+                    "Optional timezone ('Europe/Berlin'). Defaults to Ip address based timezone. Backup UTC."
+                required = false
+            }
+            queryParameter<String>("units") {
+                description =
+                    "Optional units for the measurements ('metric, imperial, custom'). Defaults to metric."
+                required = false
+            }
+        }
+        response {
+            HttpStatusCode.OK to {
+                description = "Successful response with latest measurements for each location"
+                body<UnitsWithLocationWithBoxesDTO>()
+            }
+            HttpStatusCode.InternalServerError to {
+                description = "Error occurred while retrieving the latest measurements"
+            }
+        }
+    }
+
+    val getLocationLatestMeasurements: RouteConfig.() -> Unit = {
+        tags("location")
+        description = "Get the latest measurements for a single location."
+        request {
+            pathParameter<Long>("id") {
+                description = "The location ID (not the sensor ID)"
+            }
+            queryParameter<String>("timezone") {
+                description =
+                    "Optional timezone ('Europe/Berlin'). Defaults to Ip address based timezone. Backup UTC."
+                required = false
+            }
+            queryParameter<String>("units") {
+                description =
+                    "Optional units for the measurements ('metric, imperial, custom'). Defaults to metric."
+                required = false
+            }
+        }
+        response {
+            HttpStatusCode.OK to {
+                description = "Successful response with latest measurements for a location"
+                body<UnitsWithLocationWithBoxesDTO>()
+            }
+            HttpStatusCode.InternalServerError to {
+                description = "Error occurred while retrieving the latest measurements"
+            }
+        }
+    }
+
+    val getLocationMeasurementsWithinTimeRangeV3: RouteConfig.() -> Unit = {
+        tags("location")
+        description = "Get all measurements for a location within a given time range"
+        request {
+            pathParameter<Long>("id") {
+                description = "The location ID (not the sensor ID)"
+            }
+            queryParameter<String>("timeRange") {
+                description = """Optional time range ('48h', '7d', '30d', '1y'). Defaults to 24h.
+                            |           "24h" -> raw;
+                                        "48h" -> raw;
+                                        "7d"  -> avg: 2 hours;
+                                        "30d" -> avg: 6 hours;
+                                        "90d"  -> avg: 12 hours;
+                                        "180d" -> avg: 1 day;
+                                        "1y"  -> avg: 2 days;
+                        """.trimMargin()
+                required = false
+            }
+            queryParameter<String>("timezone") {
+                description =
+                    "Optional timezone ('Europe/Berlin'). Defaults to Ip address based timezone. Backup UTC."
+                required = false
+            }
+            queryParameter<String>("units") {
+                description =
+                    "Optional units for the measurements ('metric, imperial, custom'). Defaults to metric."
+                required = false
+            }
+        }
+        response {
+            HttpStatusCode.OK to {
+                description = "Successful response with measurements"
+                body<UnitsWithLocationWithBoxesDTO>()
+            }
+            HttpStatusCode.BadRequest to {
+                description = "Invalid parameters"
+            }
+        }
+    }
+}

--- a/src/main/kotlin/hs/flensburg/marlin/business/api/sensors/boundary/SensorResources.kt
+++ b/src/main/kotlin/hs/flensburg/marlin/business/api/sensors/boundary/SensorResources.kt
@@ -1,18 +1,16 @@
 package hs.flensburg.marlin.business.api.sensors.boundary
 
+import de.lambda9.tailwind.core.KIO.Companion.unsafeRunSync
+import de.lambda9.tailwind.core.extensions.exit.getOrElse
+import de.lambda9.tailwind.core.extensions.exit.getOrNull
 import hs.flensburg.marlin.business.api.auth.entity.LoggedInUser
 import hs.flensburg.marlin.business.api.location.boundary.LocationService
-import hs.flensburg.marlin.business.api.location.entity.DetailedLocationDTO
-import hs.flensburg.marlin.business.api.sensors.entity.LocationWithBoxesDTO
-import hs.flensburg.marlin.business.api.sensors.entity.LocationWithLatestMeasurementsDTO
 import hs.flensburg.marlin.business.api.sensors.entity.SensorMeasurementsTimeRange
-import hs.flensburg.marlin.business.api.sensors.entity.UnitsWithLocationWithBoxesDTO
-import hs.flensburg.marlin.business.api.sensors.entity.raw.MeasurementDTO
-import hs.flensburg.marlin.business.api.sensors.entity.raw.MeasurementTypeDTO
-import hs.flensburg.marlin.business.api.sensors.entity.raw.SensorDTO
 import hs.flensburg.marlin.business.api.timezones.boundary.TimezonesService
 import hs.flensburg.marlin.business.api.units.boundary.UnitsService
+import hs.flensburg.marlin.business.api.openAPI.SensorsOpenAPISpec
 import hs.flensburg.marlin.plugins.Realm
+import hs.flensburg.marlin.plugins.kioEnv
 import hs.flensburg.marlin.plugins.respondKIO
 import io.github.smiley4.ktoropenapi.get
 import io.ktor.http.*
@@ -24,131 +22,32 @@ import io.ktor.server.routing.*
 
 fun Application.configureSensors() {
     routing {
-        get(
-            path = "/sensors",
-            builder = {
-                tags("raw")
-                description = "Return all sensors from the database (raw form, no aggregation)."
-                response {
-                    HttpStatusCode.OK to {
-                        description = "List of sensors"
-                        body<List<SensorDTO>>()
-                    }
-                    HttpStatusCode.InternalServerError to {
-                        description = "Error retrieving sensors"
-                    }
-                }
-            }
-        ) {
+        get("/sensors", SensorsOpenAPISpec.getAllSensors) {
             call.respondKIO(SensorService.getAllSensors())
         }
 
-        get(
-            path = "/measurementtypes",
-            builder = {
-                tags("raw")
-                description = "Return all measurement types (raw form)."
-                response {
-                    HttpStatusCode.OK to {
-                        description = "List of measurement types"
-                        body<List<MeasurementTypeDTO>>()
-                    }
-                }
-            }
-        ) {
+        get("/measurementtypes", SensorsOpenAPISpec.getAllMeasurementTypes) {
             call.respondKIO(SensorService.getAllMeasurementTypes())
         }
 
-        get(
-            path = "/locations",
-            builder = {
-                tags("location")
-                description = "Return all locations."
-                request {
-                    queryParameter<String>("timezone") {
-                        description =
-                            "Optional timezone ('Europe/Berlin'). Defaults to Ip address based timezone. Backup UTC."
-                        required = false
-                    }
-                }
-                response {
-                    HttpStatusCode.OK to {
-                        description = "List of locations"
-                        body<List<DetailedLocationDTO>>()
-                    }
-                }
-            }
-        ) {
-            val result = TimezonesService.withResolvedTimezone<List<DetailedLocationDTO>>(
+        get("/locations", SensorsOpenAPISpec.getAllLocations) {
+            val tz = TimezonesService.getClientTimeZoneFromIPOrQueryParam(
                 call.parameters["timezone"],
                 call.request.origin.remoteAddress
-            ) { tz ->
-                LocationService.getAllLocations(tz)
-            }
-            call.respondKIO(result)
+            )
+
+            call.respondKIO(LocationService.getAllLocations(tz))
         }
 
-        get(
-            path = "/measurements",
-            builder = {
-                tags("measurements")
-                description = "Return all measurements (raw form)."
-                response {
-                    HttpStatusCode.OK to {
-                        description = "List of measurements"
-                        body<List<MeasurementDTO>>()
-                    }
-                }
-            }
-        ) {
+        get("/measurements", SensorsOpenAPISpec.getAllMeasurements) {
             call.respondKIO(SensorService.getAllMeasurements())
         }
 
-        get(
-            path = "/latestmeasurements",
-            builder = {
-                tags("measurements")
-                description = "Return the latest measurement for each location (raw form)."
-                response {
-                    HttpStatusCode.OK to {
-                        description = "List of locations with their latest measurements"
-                        body<List<LocationWithLatestMeasurementsDTO>>()
-                    }
-                }
-            }
-        ) {
+        get("/latestmeasurements", SensorsOpenAPISpec.getLatestMeasurements) {
             call.respondKIO(SensorService.getLocationsWithLatestMeasurements(""))
         }
 
-        get(
-            path = "/latestmeasurementsNEW",
-            builder = {
-                tags("measurements")
-                description =
-                    "Get the latest measurement values for all locations. The measurement must be within the last 2 hours."
-                request {
-                    queryParameter<String>("timezone") {
-                        description =
-                            "Optional timezone ('Europe/Berlin'). Defaults to Ip address based timezone. Backup UTC."
-                        required = false
-                    }
-                    queryParameter<String>("units") {
-                        description =
-                            "Optional units for the measurements ('metric, imperial, custom'). Defaults to metric."
-                        required = false
-                    }
-                }
-                response {
-                    HttpStatusCode.OK to {
-                        description = "Successful response with latest measurements for each location"
-                        body<List<LocationWithBoxesDTO>>()
-                    }
-                    HttpStatusCode.InternalServerError to {
-                        description = "Error occurred while retrieving the latest measurements"
-                    }
-                }
-            }
-        ) {
+        get("/latestmeasurementsNEW", SensorsOpenAPISpec.getLatestMeasurementsNew) {
             call.respondKIO(
                 SensorService.getLocationsWithLatestMeasurementsNEW(
                     call.parameters["timezone"] ?: "DEFAULT",
@@ -158,49 +57,7 @@ fun Application.configureSensors() {
             )
         }
 
-        get(
-            path = "/location/{id}/measurementsWithinTimeRangeFAST",
-            builder = {
-                tags("location")
-                description = "Get all measurements for a location within a given time range"
-                request {
-                    pathParameter<Long>("id") {
-                        description = "The location ID (not the sensor ID)"
-                    }
-                    queryParameter<String>("timeRange") {
-                        description = """Optional time range ('48h', '7d', '30d', '1y'). Defaults to 24h.
-                            |           "24h" -> raw;
-                                        "48h" -> raw;
-                                        "7d"  -> avg: 2 hours;
-                                        "30d" -> avg: 6 hours;
-                                        "90d"  -> avg: 12 hours;
-                                        "180d" -> avg: 1 day;
-                                        "1y"  -> avg: 2 days;
-                        """.trimMargin()
-                        required = false
-                    }
-                    queryParameter<String>("timezone") {
-                        description =
-                            "Optional timezone ('Europe/Berlin'). Defaults to Ip address based timezone. Backup UTC."
-                        required = false
-                    }
-                    queryParameter<String>("units") {
-                        description =
-                            "Optional units for the measurements ('metric, imperial, custom'). Defaults to metric."
-                        required = false
-                    }
-                }
-                response {
-                    HttpStatusCode.OK to {
-                        description = "Successful response with measurements"
-                        body<LocationWithBoxesDTO>()
-                    }
-                    HttpStatusCode.BadRequest to {
-                        description = "Invalid parameters"
-                    }
-                }
-            }
-        ) {
+        get("/location/{id}/measurementsWithinTimeRangeFAST", SensorsOpenAPISpec.getLocationMeasurementsWithinTimeRangeFast) {
             val locationId = call.parameters["id"]?.toLongOrNull()
                 ?: return@get call.respondText("Missing or wrong id", status = HttpStatusCode.BadRequest)
 
@@ -220,161 +77,65 @@ fun Application.configureSensors() {
             )
         }
         authenticate(Realm.COMMON.toString(), optional = true) {
-            get(
-                path = "/latestmeasurements_v3",
-                builder = {
-                    tags("measurements")
-                    description =
-                        "Get the latest measurement values for all locations. The measurement must be within the last 2 hours. Version 3."
-                    request {
-                        queryParameter<String>("timezone") {
-                            description =
-                                "Optional timezone ('Europe/Berlin'). Defaults to Ip address based timezone. Backup UTC."
-                            required = false
-                        }
-                        queryParameter<String>("units") {
-                            description =
-                                "Optional units for the measurements ('metric, imperial, custom'). Defaults to metric."
-                            required = false
-                        }
-                    }
-                    response {
-                        HttpStatusCode.OK to {
-                            description = "Successful response with latest measurements for each location"
-                            body<UnitsWithLocationWithBoxesDTO>()
-                        }
-                        HttpStatusCode.InternalServerError to {
-                            description = "Error occurred while retrieving the latest measurements"
-                        }
-                    }
-                }
-            ) {
+            get("/latestmeasurements_v3", SensorsOpenAPISpec.getLatestMeasurementsV3) {
                 val user = call.principal<LoggedInUser>()
-                val result = UnitsService.withResolvedUnits<UnitsWithLocationWithBoxesDTO>(
-                    call.parameters["units"],
-                    user?.id
-                ) { units ->
+                val units =
+                    UnitsService.withResolvedUnits(call.parameters["units"], user?.id).unsafeRunSync(call.kioEnv)
+                        .getOrElse {
+                            return@get call.respond(HttpStatusCode.InternalServerError)
+                        }
+
+                call.respondKIO(
                     SensorService.getLocationsWithLatestMeasurementsV3(
                         call.parameters["timezone"] ?: "DEFAULT",
                         call.request.origin.remoteAddress,
                         units,
                     )
-                }
-
-                call.respondKIO(result)
+                )
             }
 
-            get(
-                path = "/location/{id}/latestmeasurements",
-                builder = {
-                    tags("location")
-                    description = "Get the latest measurements for a single location."
-                    request {
-                        pathParameter<Long>("id") {
-                            description = "The location ID (not the sensor ID)"
-                        }
-                        queryParameter<String>("timezone") {
-                            description =
-                                "Optional timezone ('Europe/Berlin'). Defaults to Ip address based timezone. Backup UTC."
-                            required = false
-                        }
-                        queryParameter<String>("units") {
-                            description =
-                                "Optional units for the measurements ('metric, imperial, custom'). Defaults to metric."
-                            required = false
-                        }
-                    }
-                    response {
-                        HttpStatusCode.OK to {
-                            description = "Successful response with latest measurements for a location"
-                            body<UnitsWithLocationWithBoxesDTO>()
-                        }
-                        HttpStatusCode.InternalServerError to {
-                            description = "Error occurred while retrieving the latest measurements"
-                        }
-                    }
-                }
-            ) {
+            get("/location/{id}/latestmeasurements", SensorsOpenAPISpec.getLocationLatestMeasurements) {
                 val locationId = call.parameters["id"]?.toLongOrNull()
                     ?: return@get call.respondText("Missing or wrong id", status = HttpStatusCode.BadRequest)
 
                 val user = call.principal<LoggedInUser>()
 
-                val result = TimezonesService.withResolvedTimezone<UnitsWithLocationWithBoxesDTO>(
+                val tz = TimezonesService.getClientTimeZoneFromIPOrQueryParam(
                     call.parameters["timezone"],
                     call.request.origin.remoteAddress
-                ) { tz ->
-                    UnitsService.withResolvedUnits(
-                        call.parameters["units"],
-                        user?.id
-                    ) { units ->
-                        SensorService.getSingleLocationWithLatestMeasurements(
-                            locationId,
-                            tz,
-                            units
-                        )
-                    }
-                }
-                call.respondKIO(result)
+                )
+
+                val units =
+                    UnitsService.withResolvedUnits(call.parameters["units"], user?.id)
+                        .unsafeRunSync(call.kioEnv)
+                        .getOrElse {
+                            return@get call.respond(HttpStatusCode.InternalServerError)
+                        }
+
+                call.respondKIO(SensorService.getSingleLocationWithLatestMeasurements(locationId, tz, units))
             }
 
-            get(
-                path = "/location/{id}/measurementsWithinTimeRange_v3",
-                builder = {
-                    tags("location")
-                    description = "Get all measurements for a location within a given time range"
-                    request {
-                        pathParameter<Long>("id") {
-                            description = "The location ID (not the sensor ID)"
-                        }
-                        queryParameter<String>("timeRange") {
-                            description = """Optional time range ('48h', '7d', '30d', '1y'). Defaults to 24h.
-                            |           "24h" -> raw;
-                                        "48h" -> raw;
-                                        "7d"  -> avg: 2 hours;
-                                        "30d" -> avg: 6 hours;
-                                        "90d"  -> avg: 12 hours;
-                                        "180d" -> avg: 1 day;
-                                        "1y"  -> avg: 2 days;
-                        """.trimMargin()
-                            required = false
-                        }
-                        queryParameter<String>("timezone") {
-                            description =
-                                "Optional timezone ('Europe/Berlin'). Defaults to Ip address based timezone. Backup UTC."
-                            required = false
-                        }
-                        queryParameter<String>("units") {
-                            description =
-                                "Optional units for the measurements ('metric, imperial, custom'). Defaults to metric."
-                            required = false
-                        }
-                    }
-                    response {
-                        HttpStatusCode.OK to {
-                            description = "Successful response with measurements"
-                            body<UnitsWithLocationWithBoxesDTO>()
-                        }
-                        HttpStatusCode.BadRequest to {
-                            description = "Invalid parameters"
-                        }
-                    }
-                }
-            ) {
+            get("/location/{id}/measurementsWithinTimeRange_v3", SensorsOpenAPISpec.getLocationMeasurementsWithinTimeRangeV3) {
                 val locationId = call.parameters["id"]?.toLongOrNull()
                     ?: return@get call.respondText("Missing or wrong id", status = HttpStatusCode.BadRequest)
 
                 val user = call.principal<LoggedInUser>()
 
-                val timeRange = SensorMeasurementsTimeRange.fromString(call.parameters["timeRange"] ?: "24h") ?: return@get call.respondText(
-                    "wrong timeRange",
-                    status = HttpStatusCode.BadRequest
-                )
+                val timeRange = SensorMeasurementsTimeRange.fromString(call.parameters["timeRange"] ?: "24h")
+                    ?: return@get call.respondText(
+                        "wrong timeRange",
+                        status = HttpStatusCode.BadRequest
+                    )
 
-                val result = UnitsService.withResolvedUnits<UnitsWithLocationWithBoxesDTO>(
-                    call.parameters["units"],
-                    user?.id
-                ) { units ->
+                val units =
+                    UnitsService.withResolvedUnits(call.parameters["units"], user?.id).unsafeRunSync(call.kioEnv)
+                        .getOrElse {
+                            return@get call.respond(HttpStatusCode.InternalServerError)
+                        }
+
+
+
+                call.respondKIO(
                     SensorService.getLocationByIDWithMeasurementsWithinTimespanV3(
                         locationId,
                         timeRange,
@@ -382,12 +143,8 @@ fun Application.configureSensors() {
                         call.request.origin.remoteAddress,
                         units,
                     )
-                }
-
-                call.respondKIO(result)
-
+                )
             }
         }
-
     }
 }

--- a/src/main/kotlin/hs/flensburg/marlin/business/api/sensors/boundary/SensorResources.kt
+++ b/src/main/kotlin/hs/flensburg/marlin/business/api/sensors/boundary/SensorResources.kt
@@ -11,6 +11,7 @@ import hs.flensburg.marlin.business.api.sensors.entity.raw.MeasurementDTO
 import hs.flensburg.marlin.business.api.sensors.entity.raw.MeasurementTypeDTO
 import hs.flensburg.marlin.business.api.sensors.entity.raw.SensorDTO
 import hs.flensburg.marlin.business.api.timezones.boundary.TimezonesService
+import hs.flensburg.marlin.plugins.Realm
 import hs.flensburg.marlin.plugins.respondKIO
 import io.github.smiley4.ktoropenapi.get
 import io.ktor.http.*
@@ -157,46 +158,6 @@ fun Application.configureSensors() {
         }
 
         get(
-            path = "/latestmeasurements_v3",
-            builder = {
-                tags("measurements")
-                description =
-                    "Get the latest measurement values for all locations. The measurement must be within the last 2 hours. Version 3."
-                request {
-                    queryParameter<String>("timezone") {
-                        description =
-                            "Optional timezone ('Europe/Berlin'). Defaults to Ip address based timezone. Backup UTC."
-                        required = false
-                    }
-                    queryParameter<String>("units") {
-                        description =
-                            "Optional units for the measurements ('metric, imperial, custom'). Defaults to metric."
-                        required = false
-                    }
-                }
-                response {
-                    HttpStatusCode.OK to {
-                        description = "Successful response with latest measurements for each location"
-                        body<UnitsWithLocationWithBoxesDTO>()
-                    }
-                    HttpStatusCode.InternalServerError to {
-                        description = "Error occurred while retrieving the latest measurements"
-                    }
-                }
-            }
-        ) {
-            val user = call.principal<LoggedInUser>()
-            call.respondKIO(
-                SensorService.getLocationsWithLatestMeasurementsV3(
-                    call.parameters["timezone"] ?: "DEFAULT",
-                    call.request.origin.remoteAddress,
-                    call.parameters["units"],
-                    user?.id
-                )
-            )
-        }
-
-        get(
             path = "/location/{id}/measurementsWithinTimeRangeFAST",
             builder = {
                 tags("location")
@@ -257,18 +218,58 @@ fun Application.configureSensors() {
                 )
             )
         }
-
-        get(
-            path = "/location/{id}/measurementsWithinTimeRange_v3",
-            builder = {
-                tags("location")
-                description = "Get all measurements for a location within a given time range"
-                request {
-                    pathParameter<Long>("id") {
-                        description = "The location ID (not the sensor ID)"
+        authenticate(Realm.COMMON.toString(), optional = true) {
+            get(
+                path = "/latestmeasurements_v3",
+                builder = {
+                    tags("measurements")
+                    description =
+                        "Get the latest measurement values for all locations. The measurement must be within the last 2 hours. Version 3."
+                    request {
+                        queryParameter<String>("timezone") {
+                            description =
+                                "Optional timezone ('Europe/Berlin'). Defaults to Ip address based timezone. Backup UTC."
+                            required = false
+                        }
+                        queryParameter<String>("units") {
+                            description =
+                                "Optional units for the measurements ('metric, imperial, custom'). Defaults to metric."
+                            required = false
+                        }
                     }
-                    queryParameter<String>("timeRange") {
-                        description = """Optional time range ('48h', '7d', '30d', '1y'). Defaults to 24h.
+                    response {
+                        HttpStatusCode.OK to {
+                            description = "Successful response with latest measurements for each location"
+                            body<UnitsWithLocationWithBoxesDTO>()
+                        }
+                        HttpStatusCode.InternalServerError to {
+                            description = "Error occurred while retrieving the latest measurements"
+                        }
+                    }
+                }
+            ) {
+                val user = call.principal<LoggedInUser>()
+                call.respondKIO(
+                    SensorService.getLocationsWithLatestMeasurementsV3(
+                        call.parameters["timezone"] ?: "DEFAULT",
+                        call.request.origin.remoteAddress,
+                        call.parameters["units"],
+                        user?.id
+                    )
+                )
+            }
+
+            get(
+                path = "/location/{id}/measurementsWithinTimeRange_v3",
+                builder = {
+                    tags("location")
+                    description = "Get all measurements for a location within a given time range"
+                    request {
+                        pathParameter<Long>("id") {
+                            description = "The location ID (not the sensor ID)"
+                        }
+                        queryParameter<String>("timeRange") {
+                            description = """Optional time range ('48h', '7d', '30d', '1y'). Defaults to 24h.
                             |           "24h" -> raw;
                                         "48h" -> raw;
                                         "7d"  -> avg: 2 hours;
@@ -277,47 +278,51 @@ fun Application.configureSensors() {
                                         "180d" -> avg: 1 day;
                                         "1y"  -> avg: 2 days;
                         """.trimMargin()
-                        required = false
+                            required = false
+                        }
+                        queryParameter<String>("timezone") {
+                            description =
+                                "Optional timezone ('Europe/Berlin'). Defaults to Ip address based timezone. Backup UTC."
+                            required = false
+                        }
+                        queryParameter<String>("units") {
+                            description =
+                                "Optional units for the measurements ('metric, imperial, custom'). Defaults to metric."
+                            required = false
+                        }
                     }
-                    queryParameter<String>("timezone") {
-                        description =
-                            "Optional timezone ('Europe/Berlin'). Defaults to Ip address based timezone. Backup UTC."
-                        required = false
-                    }
-                    queryParameter<String>("units") {
-                        description =
-                            "Optional units for the measurements ('metric, imperial, custom'). Defaults to metric."
-                        required = false
+                    response {
+                        HttpStatusCode.OK to {
+                            description = "Successful response with measurements"
+                            body<UnitsWithLocationWithBoxesDTO>()
+                        }
+                        HttpStatusCode.BadRequest to {
+                            description = "Invalid parameters"
+                        }
                     }
                 }
-                response {
-                    HttpStatusCode.OK to {
-                        description = "Successful response with measurements"
-                        body<UnitsWithLocationWithBoxesDTO>()
-                    }
-                    HttpStatusCode.BadRequest to {
-                        description = "Invalid parameters"
-                    }
-                }
-            }
-        ) {
-            val locationId = call.parameters["id"]?.toLongOrNull()
-                ?: return@get call.respondText("Missing or wrong id", status = HttpStatusCode.BadRequest)
+            ) {
+                val locationId = call.parameters["id"]?.toLongOrNull()
+                    ?: return@get call.respondText("Missing or wrong id", status = HttpStatusCode.BadRequest)
 
-            val timeRange = call.parameters["timeRange"] ?: "24h"
+                val timeRange = call.parameters["timeRange"] ?: "24h"
 
-            call.respondKIO(
-                SensorService.getLocationByIDWithMeasurementsWithinTimespanV3(
-                    locationId,
-                    SensorMeasurementsTimeRange.fromString(timeRange) ?: return@get call.respondText(
-                        "wrong timeRange",
-                        status = HttpStatusCode.BadRequest
-                    ),
-                    call.parameters["timezone"] ?: "DEFAULT",
-                    call.request.origin.remoteAddress,
-                    call.parameters["units"] ?: "metric"
+                val user = call.principal<LoggedInUser>()
+
+                call.respondKIO(
+                    SensorService.getLocationByIDWithMeasurementsWithinTimespanV3(
+                        locationId,
+                        SensorMeasurementsTimeRange.fromString(timeRange) ?: return@get call.respondText(
+                            "wrong timeRange",
+                            status = HttpStatusCode.BadRequest
+                        ),
+                        call.parameters["timezone"] ?: "DEFAULT",
+                        call.request.origin.remoteAddress,
+                        call.parameters["units"],
+                        user?.id
+                    )
                 )
-            )
+            }
         }
 
     }

--- a/src/main/kotlin/hs/flensburg/marlin/business/api/sensors/boundary/SensorResources.kt
+++ b/src/main/kotlin/hs/flensburg/marlin/business/api/sensors/boundary/SensorResources.kt
@@ -159,53 +159,6 @@ fun Application.configureSensors() {
         }
 
         get(
-            path = "/location/{id}/latestmeasurements",
-            builder = {
-                tags("location")
-                description = "Get the latest measurements for a single location."
-                request {
-                    pathParameter<Long>("id") {
-                        description = "The location ID (not the sensor ID)"
-                    }
-                    queryParameter<String>("timezone") {
-                        description =
-                            "Optional timezone ('Europe/Berlin'). Defaults to Ip address based timezone. Backup UTC."
-                        required = false
-                    }
-                    queryParameter<String>("units") {
-                        description =
-                            "Optional units for the measurements ('metric, imperial, custom'). Defaults to metric."
-                        required = false
-                    }
-                }
-                response {
-                    HttpStatusCode.OK to {
-                        description = "Successful response with latest measurements for a location"
-                        body<UnitsWithLocationWithBoxesDTO>()
-                    }
-                    HttpStatusCode.InternalServerError to {
-                        description = "Error occurred while retrieving the latest measurements"
-                    }
-                }
-            }
-        ) {
-            val locationId = call.parameters["id"]?.toLongOrNull()
-                ?: return@get call.respondText("Missing or wrong id", status = HttpStatusCode.BadRequest)
-
-            val result = TimezonesService.withResolvedTimezone<UnitsWithLocationWithBoxesDTO>(
-                call.parameters["timezone"],
-                call.request.origin.remoteAddress
-            ) { tz ->
-                SensorService.getSingleLocationWithLatestMeasurements(
-                    locationId,
-                    tz,
-                    call.parameters["units"] ?: "metric"
-                )
-            }
-            call.respondKIO(result)
-        }
-
-        get(
             path = "/location/{id}/measurementsWithinTimeRangeFAST",
             builder = {
                 tags("location")
@@ -308,6 +261,60 @@ fun Application.configureSensors() {
                     )
                 }
 
+                call.respondKIO(result)
+            }
+
+            get(
+                path = "/location/{id}/latestmeasurements",
+                builder = {
+                    tags("location")
+                    description = "Get the latest measurements for a single location."
+                    request {
+                        pathParameter<Long>("id") {
+                            description = "The location ID (not the sensor ID)"
+                        }
+                        queryParameter<String>("timezone") {
+                            description =
+                                "Optional timezone ('Europe/Berlin'). Defaults to Ip address based timezone. Backup UTC."
+                            required = false
+                        }
+                        queryParameter<String>("units") {
+                            description =
+                                "Optional units for the measurements ('metric, imperial, custom'). Defaults to metric."
+                            required = false
+                        }
+                    }
+                    response {
+                        HttpStatusCode.OK to {
+                            description = "Successful response with latest measurements for a location"
+                            body<UnitsWithLocationWithBoxesDTO>()
+                        }
+                        HttpStatusCode.InternalServerError to {
+                            description = "Error occurred while retrieving the latest measurements"
+                        }
+                    }
+                }
+            ) {
+                val locationId = call.parameters["id"]?.toLongOrNull()
+                    ?: return@get call.respondText("Missing or wrong id", status = HttpStatusCode.BadRequest)
+
+                val user = call.principal<LoggedInUser>()
+
+                val result = TimezonesService.withResolvedTimezone<UnitsWithLocationWithBoxesDTO>(
+                    call.parameters["timezone"],
+                    call.request.origin.remoteAddress
+                ) { tz ->
+                    UnitsService.withResolvedUnits(
+                        call.parameters["units"],
+                        user?.id
+                    ) { units ->
+                        SensorService.getSingleLocationWithLatestMeasurements(
+                            locationId,
+                            tz,
+                            units
+                        )
+                    }
+                }
                 call.respondKIO(result)
             }
 

--- a/src/main/kotlin/hs/flensburg/marlin/business/api/sensors/boundary/SensorResources.kt
+++ b/src/main/kotlin/hs/flensburg/marlin/business/api/sensors/boundary/SensorResources.kt
@@ -1,5 +1,6 @@
 package hs.flensburg.marlin.business.api.sensors.boundary
 
+import hs.flensburg.marlin.business.api.auth.entity.LoggedInUser
 import hs.flensburg.marlin.business.api.location.boundary.LocationService
 import hs.flensburg.marlin.business.api.location.entity.DetailedLocationDTO
 import hs.flensburg.marlin.business.api.sensors.entity.LocationWithBoxesDTO
@@ -12,11 +13,12 @@ import hs.flensburg.marlin.business.api.sensors.entity.raw.SensorDTO
 import hs.flensburg.marlin.business.api.timezones.boundary.TimezonesService
 import hs.flensburg.marlin.plugins.respondKIO
 import io.github.smiley4.ktoropenapi.get
-import io.ktor.http.HttpStatusCode
-import io.ktor.server.application.Application
-import io.ktor.server.plugins.origin
-import io.ktor.server.response.respondText
-import io.ktor.server.routing.routing
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.auth.*
+import io.ktor.server.plugins.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
 
 fun Application.configureSensors() {
     routing {
@@ -183,11 +185,13 @@ fun Application.configureSensors() {
                 }
             }
         ) {
+            val user = call.principal<LoggedInUser>()
             call.respondKIO(
                 SensorService.getLocationsWithLatestMeasurementsV3(
                     call.parameters["timezone"] ?: "DEFAULT",
                     call.request.origin.remoteAddress,
-                    call.parameters["units"] ?: "metric"
+                    call.parameters["units"],
+                    user?.id
                 )
             )
         }

--- a/src/main/kotlin/hs/flensburg/marlin/business/api/sensors/boundary/SensorService.kt
+++ b/src/main/kotlin/hs/flensburg/marlin/business/api/sensors/boundary/SensorService.kt
@@ -61,26 +61,6 @@ object SensorService {
                 }
         }
 
-    fun getLocationsWithLatestMeasurementsV3(
-        timezone: String,
-        ipAddress: String,
-        units: String?,
-        userId: Long?
-    ): App<Error, UnitsWithLocationWithBoxesDTO> = KIO.comprehension {
-        val finalUnits: String? = userId?.let { id ->
-            val userView = !UserRepo.fetchViewById(id).orDie()
-            userView?.let { view ->
-                UserProfile.from(view).measurementSystem?.literal
-            }
-        }
-
-        val rawLocations = !SensorRepo.fetchLocationsWithLatestMeasurements(
-            !TimezonesService.getClientTimeZoneFromIPOrQueryParam(timezone, ipAddress),
-            units ?: finalUnits ?: "metric"
-        ).orDie().onNullFail { Error.NotFound }
-            KIO.ok(mapToUnitsWithLocationWithBoxesDTO(rawLocations))
-        }
-
     fun getLocationByIDWithMeasurementsWithinTimespanFAST(
         locationId: Long,
         timeRange: SensorMeasurementsTimeRange,
@@ -97,17 +77,43 @@ object SensorService {
             .map { it.toLocationWithBoxesDTO() }
     }
 
+    fun getLocationsWithLatestMeasurementsV3(
+        timezone: String,
+        ipAddress: String,
+        units: String?,
+        userId: Long?
+    ): App<Error, UnitsWithLocationWithBoxesDTO> = KIO.comprehension {
+        val finalUnits: String = units ?: userId?.let { id ->
+            val userView = !UserRepo.fetchViewById(id).orDie()
+            userView?.let { view ->
+                UserProfile.from(view).measurementSystem?.literal?.lowercase()
+            }
+        } ?: "metric"
+        val rawLocations = !SensorRepo.fetchLocationsWithLatestMeasurements(
+            !TimezonesService.getClientTimeZoneFromIPOrQueryParam(timezone, ipAddress),
+            finalUnits
+        ).orDie().onNullFail { Error.NotFound }
+        KIO.ok(mapToUnitsWithLocationWithBoxesDTO(rawLocations))
+    }
+
     fun getLocationByIDWithMeasurementsWithinTimespanV3(
         locationId: Long,
         timeRange: SensorMeasurementsTimeRange,
         timezone: String,
         ipAddress: String,
-        units: String
+        units: String?,
+        userId: Long?
     ): App<Error, UnitsWithLocationWithBoxesDTO> = KIO.comprehension {
+        val finalUnits: String = units ?: userId?.let { id ->
+            val userView = !UserRepo.fetchViewById(id).orDie()
+            userView?.let { view ->
+                UserProfile.from(view).measurementSystem?.literal?.lowercase()
+            }
+        } ?: "metric"
         SensorRepo.getLatestMeasurementTimeEnriched(
             locationId, timeRange,
             timezone = !TimezonesService.getClientTimeZoneFromIPOrQueryParam(timezone, ipAddress),
-            units
+            finalUnits
         ).orDie().onNullFail { Error.NotFound }.map { mapToUnitsWithLocationWithBoxesDTO(listOf(it)) }
     }
 

--- a/src/main/kotlin/hs/flensburg/marlin/business/api/sensors/boundary/SensorService.kt
+++ b/src/main/kotlin/hs/flensburg/marlin/business/api/sensors/boundary/SensorService.kt
@@ -92,14 +92,8 @@ object SensorService {
         ipAddress: String,
         units: String
     ): App<Error, UnitsWithLocationWithBoxesDTO> = KIO.comprehension {
-        /*val finalUnits: String = units ?: userId?.let { id ->
-            val userView = !UserRepo.fetchViewById(id).orDie()
-            userView?.let { view ->
-                UserProfile.from(view).measurementSystem?.literal?.lowercase()
-            }
-        } ?: "metric"*/
         val rawLocations = !SensorRepo.fetchLocationsWithLatestMeasurements(
-            !TimezonesService.getClientTimeZoneFromIPOrQueryParam(timezone, ipAddress),
+            TimezonesService.getClientTimeZoneFromIPOrQueryParam(timezone, ipAddress),
             units
         ).orDie().onNullFail { Error.NotFound }
         KIO.ok(mapToUnitsWithLocationWithBoxesDTO(rawLocations))

--- a/src/main/kotlin/hs/flensburg/marlin/business/api/timezones/boundary/TimezonesService.kt
+++ b/src/main/kotlin/hs/flensburg/marlin/business/api/timezones/boundary/TimezonesService.kt
@@ -41,9 +41,9 @@ object TimezonesService {
         return toLocalDateTimeInZone(utcTime, timezone).date
     }
 
-    fun getClientTimeZoneFromIPOrQueryParam(timezone: String, clientIp: String): String {
+    fun getClientTimeZoneFromIPOrQueryParam(timezone: String?, clientIp: String): String {
         // optional query param overwrites IP-based timezone
-        if (timezone != "DEFAULT" && isValidTimezone(timezone)) {
+        if (timezone != null && isValidTimezone(timezone)) {
             return timezone
         }
 
@@ -63,18 +63,16 @@ object TimezonesService {
 
     // This function is used in routing to determine the timezone
     // is provided or retrieved via Ipaddress
-    fun <T> withResolvedTimezone(
+    fun withResolvedTimezone(
         timezoneParam: String?,
-        remoteIp: String,
-        block: (resolvedTimezone: String) -> App<ServiceLayerError, T>
-    ): App<ServiceLayerError, T> = KIO.comprehension {
-
+        remoteIp: String
+    ): String {
         val timezone = getClientTimeZoneFromIPOrQueryParam(
             timezone = timezoneParam ?: "DEFAULT",
             clientIp = remoteIp
         )
-        // function to run with timezone
-        block(timezone)
+
+        return timezone
     }
 
 

--- a/src/main/kotlin/hs/flensburg/marlin/business/api/units/boundary/UnitsService.kt
+++ b/src/main/kotlin/hs/flensburg/marlin/business/api/units/boundary/UnitsService.kt
@@ -5,7 +5,8 @@ import kotlin.math.PI
 
 object UnitsService {
 
-    const val CELSIUS_TO_FAHRENHEIT_FACTOR = 9 / 5 + 32
+    const val CELSIUS_TO_FAHRENHEIT_FACTOR = 9.0 / 5.0
+    const val CELSIUS_TO_FAHRENHEIT_OFFSET = 32
     const val CELSIUS_TO_KELVIN_SUMMAND = 273.15
     const val METERS_PER_SECOND_TO_KILOMETERS_PER_HOUR_FACTOR = 3.6
     const val METERS_PER_SECOND_TO_MILES_PER_HOUR_DIVISOR = 0.44704
@@ -45,7 +46,7 @@ object UnitsService {
     )
 
     fun convert(value: Double, measurementName: String, unitSymbol: String, goal: String): ConvertedValueDTO {
-        return when (goal) {
+        return when (goal.lowercase()) {
             "", "metric" -> mapMetric(value, unitSymbol)
             "imperial" -> mapImperial(value, unitSymbol)
             "shipping" -> mapShipping(value, unitSymbol)
@@ -123,7 +124,7 @@ object UnitsService {
 
         when (sourceUnit to targetUnit) {
             // temperature
-            "°C" to "°F", "Cel" to "°F" -> convertedValue = value * CELSIUS_TO_FAHRENHEIT_FACTOR
+            "°C" to "°F", "Cel" to "°F" -> convertedValue = value * CELSIUS_TO_FAHRENHEIT_FACTOR + CELSIUS_TO_FAHRENHEIT_OFFSET
             "°C" to "K"-> convertedValue = value + CELSIUS_TO_KELVIN_SUMMAND
 
             // speed

--- a/src/main/kotlin/hs/flensburg/marlin/business/api/units/boundary/UnitsService.kt
+++ b/src/main/kotlin/hs/flensburg/marlin/business/api/units/boundary/UnitsService.kt
@@ -17,7 +17,7 @@ object UnitsService {
     const val METERS_PER_SECOND_TO_KILOMETERS_PER_HOUR_FACTOR = 3.6
     const val METERS_PER_SECOND_TO_MILES_PER_HOUR_DIVISOR = 0.44704
     const val METERS_PER_SECOND_TO_KNOTS_FACTOR = 1.943844
-    const val DEGREES_TO_RADIANS_FACTOR = PI/180
+    const val DEGREES_TO_RADIANS_FACTOR = PI / 180
     const val HECTOPASCAL_TO_INCH_OF_MERCURY_FACTOR = 0.02953
     const val HECTOPASCAL_TO_POUND_PER_SQUARE_INCH_FACTOR = 0.0145037738
     const val CENTIMETER_TO_INCHES_DEVISOR = 2.54
@@ -131,7 +131,7 @@ object UnitsService {
         when (sourceUnit to targetUnit) {
             // temperature
             "°C" to "°F", "Cel" to "°F" -> convertedValue = value * CELSIUS_TO_FAHRENHEIT_FACTOR + CELSIUS_TO_FAHRENHEIT_OFFSET
-            "°C" to "K"-> convertedValue = value + CELSIUS_TO_KELVIN_SUMMAND
+            "°C" to "K" -> convertedValue = value + CELSIUS_TO_KELVIN_SUMMAND
 
             // speed
             "m/s" to "km/h" -> convertedValue = value * METERS_PER_SECOND_TO_KILOMETERS_PER_HOUR_FACTOR
@@ -172,17 +172,14 @@ object UnitsService {
         return ConvertedValueDTO(convertedValue, targetUnit)
     }
 
-    fun <T> withResolvedUnits(
+    fun withResolvedUnits(
         units: String?,
-        userId: Long?,
-        block: (resolvedUnits: String) -> App<ServiceLayerError, T>
-    ): App<ServiceLayerError, T> = KIO.comprehension {
-        val resolvedUnits = units ?: userId?.let { id ->
-            val userView = !UserRepo.fetchViewById(id).orDie()
-            userView?.let { view ->
-                UserProfile.from(view).measurementSystem?.literal?.lowercase()
-        }
-    } ?: "metric"
-        block(resolvedUnits)
+        userId: Long?
+    ): App<ServiceLayerError, String> = KIO.comprehension {
+        KIO.ok(
+            units ?: userId?.let { id ->
+                (!UserRepo.fetchMeasurementSystemByUserId(id).orDie())?.name
+            } ?: "metric"
+        )
     }
 }

--- a/src/main/kotlin/hs/flensburg/marlin/business/api/users/control/UserRepo.kt
+++ b/src/main/kotlin/hs/flensburg/marlin/business/api/users/control/UserRepo.kt
@@ -105,6 +105,13 @@ object UserRepo {
             .fetchOneInto(UserView::class.java)
     }
 
+    fun fetchMeasurementSystemByUserId(userId: Long): JIO<MeasurementSystem?> = Jooq.query {
+        select(USER_PROFILE.MEASUREMENT_SYSTEM)
+            .from(USER_PROFILE)
+            .where(USER_PROFILE.USER_ID.eq(userId))
+            .fetchOneInto(MeasurementSystem::class.java)
+    }
+
     fun fetchRecentActivity(userId: Long): JIO<PageResult<String>> = Jooq.query {
         val blacklistEntries = select(LOGIN_BLACKLIST)
             .where(LOGIN_BLACKLIST.USER_ID.eq(userId))
@@ -266,5 +273,4 @@ object UserRepo {
             .set(HARBOR_MASTER_LOCATION.ASSIGNED_BY, assignedBy)
             .execute()
     }
-
 }


### PR DESCRIPTION
Implemented logic, to use the units that logged in user set in their profiles, if no explicit units are given. Still defaults to metric.